### PR TITLE
solved error that says The 'clr-namespace' URI refers to a namespace …

### DIFF
--- a/src/SampleProject/MainWindow.xaml
+++ b/src/SampleProject/MainWindow.xaml
@@ -6,7 +6,7 @@
         xmlns:local="clr-namespace:SampleProject"
         xmlns:persianDateControls="clr-namespace:Mohsen.PersianDateControls;assembly=Mohsen.PersianDateControls"
         mc:Ignorable="d" 
-        xmlns:system="clr-namespace:System"
+        xmlns:system="clr-namespace:System;assembly=System.Runtime"
         Loaded="Window_Loaded" Height="272" Width="440"  MinHeight="260" MinWidth="400"
         Title="MainWindow" >
     <Window.Resources>


### PR DESCRIPTION
On VS 2019, though the sample app got build successfully, the _design view_ failed to show anything. This pull request has fixed this problem. 
Changes are based on [this](https://stackoverflow.com/questions/60033916/getting-an-error-trying-to-use-system-namespace-in-xaml) SO post